### PR TITLE
Refactor add impl to be shorter and cleaner

### DIFF
--- a/src/main/java/com/lumingwu/immutable/list/ImmutableList.java
+++ b/src/main/java/com/lumingwu/immutable/list/ImmutableList.java
@@ -39,6 +39,7 @@ public interface ImmutableList<E> extends Iterable<E> {
 
     public int indexOf(Object object);
 
+    /*
     public boolean contains(Object object);
 
     public boolean containsAll(Collection<?> collection);
@@ -76,6 +77,8 @@ public interface ImmutableList<E> extends Iterable<E> {
     public Object[] toArray();
 
     public <T> T[] toArray(T[] array);
+
+     */
 
     public boolean equals(Object o);
 

--- a/src/main/java/com/lumingwu/immutable/list/arraylist/ImmutableArrayList.java
+++ b/src/main/java/com/lumingwu/immutable/list/arraylist/ImmutableArrayList.java
@@ -17,13 +17,40 @@ import com.lumingwu.immutable.list.ImmutableListBatchResult;
 import com.lumingwu.immutable.list.ImmutableListResult;
 import com.lumingwu.immutable.list.ImmutableListStatusResult;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.RandomAccess;
+import java.util.*;
 import java.util.function.UnaryOperator;
 
 public class ImmutableArrayList<E> implements ImmutableList<E>, RandomAccess {
+
+    private int branchFactor;
+    private int capacity;
+    private int size;
+    private Object[] list;
+
+    public ImmutableArrayList(int branchFactor) {
+        this(branchFactor, (int)Math.pow(2, branchFactor), 0);
+        this.branchFactor = branchFactor;
+    }
+
+    private ImmutableArrayList(ImmutableArrayList<E> immutableArrayList, int newSize) {
+        this(immutableArrayList.branchFactor, immutableArrayList.capacity, newSize);
+        list = immutableArrayList.list.clone();
+    }
+
+    private ImmutableArrayList(int branchFactor, int capacity, int size) {
+        if(branchFactor < 1) {
+            throw new IllegalArgumentException("Branch factor is less than 1.");
+        }
+        if(branchFactor > 30) {
+            throw new IllegalArgumentException("Branch factor is larger than 30.");
+        }
+
+        this.branchFactor = branchFactor;
+        this.capacity = capacity;
+        this.size = size;
+
+        list = new Object[branchFactor];
+    }
 
     @Override
     public ImmutableList<E> add(E item) {
@@ -57,271 +84,22 @@ public class ImmutableArrayList<E> implements ImmutableList<E>, RandomAccess {
 
     @Override
     public boolean isEmpty() {
-        return false;
+        return size == 0;
     }
 
     @Override
     public int size() {
-        return 0;
+        return size;
     }
 
     @Override
-    public E get(int index) {
-        return null;
-    }
-
-    @Override
-    public int indexOf(Object object) {
-        return 0;
-    }
-
-    @Override
-    public boolean contains(Object object) {
-        return false;
-    }
-
-    @Override
-    public boolean containsAll(Collection<?> collection) {
-        return false;
-    }
-
-    @Override
-    public boolean containsAll(ImmutableList<?> immutableList) {
-        return false;
-    }
-
-    @Override
-    public ImmutableListResult<E> set(int index, E element) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListBatchResult<E> set(int index, Collection<E> collection) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListBatchResult<E> set(int index, ImmutableList<E> immutableList) {
-        return null;
-    }
-
-    @Override
-    public ImmutableList<E> replaceAll(UnaryOperator<E> operator) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListStatusResult retainAll(Collection<?> collection) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListStatusResult retainAll(ImmutableList<?> immutableList) {
-        return null;
-    }
-
-    @Override
-    public ImmutableList<E> sort(Comparator<? super E> comparator) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListResult<E> remove(int index) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListBatchResult<E> removeAll(int start, int end) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListStatusResult<E> remove(Object object) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListStatusResult<E> removeAll(Collection<?> collection) {
-        return null;
-    }
-
-    @Override
-    public ImmutableListStatusResult<E> removeAll(ImmutableList<? extends E> immutableList) {
-        return null;
-    }
-
-    @Override
-    public Iterator<E> iterator() {
-        return null;
-    }
-
-    @Override
-    public ImmutableList<E> subList(int fromIndex, int toIndex) {
-        return null;
-    }
-
-    @Override
-    public Object[] toArray() {
-        return new Object[0];
-    }
-
-    @Override
-    public <T> T[] toArray(T[] array) {
-        return null;
-    }
-
-    /*
-    private int branchFactor;
-    private int capacity;
-    private int size;
-    private Object[] list;
-
-    public ImmutableArrayList(int multiplier) {
-        this(multiplier,multiplier,0);
-        this.branchFactor = multiplier;
-    }
-
-    private ImmutableArrayList(ImmutableArrayList<E> immutableArrayList, int newSize) {
-        this(immutableArrayList.branchFactor, immutableArrayList.capacity, newSize);
-        list = immutableArrayList.list.clone();
-    }
-
-    private ImmutableArrayList(int multiplier, int capacity, int size) {
-        if(multiplier < 2) {
-            throw new IllegalArgumentException("Multiplier must be at least 2");
-        }
-        this.branchFactor = multiplier;
-        this.capacity = capacity;
-        this.size = size;
-
-        list = new Object[multiplier];
-    }
-    */
-
-    /**
-     * Create a new ImmutableArrayList that added zero or more {@items} starting at {@index}. All original items starting at
-     * {@index} will shift right to make space.
-     *
-     * @param index - index at which the specified element is to be inserted
-     * @param items
-     *
-     * @return a reference of the new ImmutableArrayList represents the new state after the operation
-     *
-     * @throws IndexOutOfBoundsException if the index is out of range (index < 0 || index > size())
-     */
-    /*
-    public ImmutableArrayList<E> add(int index, E... items) {
-        if(index < 0 || index > size) {
-            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
-        }
-
-        int itemsLength = items.length;
-        int itemIndex = 0;
-        int toAddSize = itemsLength;
-        Stack<E> shiftItemStack = new Stack<E>();
-
-        Stack<BacktrackValues<E>> searchStack = new Stack<BacktrackValues<E>>();
-        ImmutableArrayList<E> searchList = new ImmutableArrayList(this, Math.min(size + toAddSize, capacity));
-
-        while(itemIndex < itemsLength) {
-            if(searchList.size < searchList.capacity) {
-                while(index >= branchFactor) {
-                    int nextSearchListCapacity = searchList.capacity / branchFactor;
-                    int nextSearchListIndex = index / nextSearchListCapacity;
-                    int padding = nextSearchListIndex * nextSearchListCapacity;
-                    ImmutableArrayList<E> nextSearchList = (ImmutableArrayList<E>) searchList.list[nextSearchListIndex];
-                    if (nextSearchList == null) {
-                        nextSearchList = new ImmutableArrayList<E>(branchFactor, nextSearchListCapacity, Math.min(toAddSize, nextSearchListCapacity));
-                    } else {
-                        nextSearchList = new ImmutableArrayList<E>(nextSearchList, Math.min(nextSearchList.size + toAddSize, nextSearchList.capacity));
-                    }
-                    searchStack.push(new BacktrackValues<E>(searchList, padding));
-                    searchList = nextSearchList;
-                    index -= padding;
-                }
-                while(index < searchList.size && itemIndex < itemsLength){
-                    shiftItemStack.addFirst((E)searchList.list[index]);
-                    searchList.list[index] = items[itemIndex];
-                    itemIndex++;
-                    index++;
-                }
-                while(index < searchList.capacity && itemIndex < itemsLength) {
-                    searchList.list[index] = items[itemIndex];
-                    toAddSize--;
-                    itemIndex++;
-                    index++;
-                }
-            }
-            if(itemIndex == itemsLength) {
-                break;
-            }
-            while(!searchStack.isEmpty() && searchList.size == searchList.capacity) {
-                BacktrackValues<E> iterateValue = searchStack.pop();
-                searchList = iterateValue.list;
-                index += iterateValue.padding;
-            }
-            if(searchList.size == searchList.capacity) {
-                int expandListCapacity = searchList.capacity * branchFactor;
-                ImmutableArrayList<E> expandList = new ImmutableArrayList<E>(branchFactor, expandListCapacity, Math.min(searchList.size + toAddSize, expandListCapacity));
-                expandList.list[0] = searchList;
-                searchList = expandList;
-            }
-        }
-        while(toAddSize > 0) {
-            if(searchList.size < searchList.capacity) {
-                while(index >= branchFactor) {
-                    int nextSearchListCapacity = searchList.capacity / branchFactor;
-                    int nextSearchListIndex = index / nextSearchListCapacity;
-                    int padding = nextSearchListIndex * nextSearchListCapacity;
-                    ImmutableArrayList<E> nextSearchList = (ImmutableArrayList<E>) searchList.list[nextSearchListIndex];
-                    if (nextSearchList == null) {
-                        nextSearchList = new ImmutableArrayList<E>(branchFactor, nextSearchListCapacity, Math.min(toAddSize, nextSearchListCapacity));
-                    } else {
-                        nextSearchList = new ImmutableArrayList<E>(nextSearchList, Math.min(nextSearchList.size + toAddSize, nextSearchList.capacity));
-                    }
-                    searchStack.push(new BacktrackValues<E>(searchList, padding));
-                    searchList = nextSearchList;
-                    index -= padding;
-                }
-                while(index < searchList.size && toAddSize > 0){
-                    shiftItemStack.addFirst((E)searchList.list[index]);
-                    searchList.list[index] = shiftItemStack.pop();
-                    index++;
-                }
-                while(index < searchList.capacity && toAddSize > 0) {
-                    searchList.list[index] = shiftItemStack.pop();
-                    toAddSize--;
-                    index++;
-                }
-            }
-            if(toAddSize == 0) {
-                break;
-            }
-            while(!searchStack.isEmpty() && searchList.size == searchList.capacity) {
-                BacktrackValues<E> iterateValue = searchStack.pop();
-                searchList = iterateValue.list;
-                index += iterateValue.padding;
-            }
-            if(searchList.size == searchList.capacity) {
-                int expandListCapacity = searchList.capacity * branchFactor;
-                ImmutableArrayList<E> expandList = new ImmutableArrayList<E>(branchFactor, expandListCapacity, Math.min(searchList.size + toAddSize, expandListCapacity));
-                expandList.list[0] = searchList;
-                searchList = expandList;
-            }
-        }
-        if(searchStack.isEmpty()) {
-            return searchList;
-        }
-        return searchStack.getFirst().list;
-    }
-
     public E get(int index) {
         if(index < 0 || index >= size) {
             throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
         }
         ImmutableArrayList<E> searchList = this;
-        while(index > branchFactor) {
-            int nextSearchListCapacity = searchList.capacity / branchFactor;
+        while(index > capacity) {
+            int nextSearchListCapacity = searchList.capacity >> branchFactor;
             int nextSearchListIndex = index / nextSearchListCapacity;
             searchList = (ImmutableArrayList<E>)searchList.list[nextSearchListIndex];
             index = index - nextSearchListIndex * nextSearchListCapacity;
@@ -329,17 +107,120 @@ public class ImmutableArrayList<E> implements ImmutableList<E>, RandomAccess {
         return (E)searchList.list[index];
     }
 
-    public int size() {
-        return size;
+    @Override
+    public int indexOf(Object object) {
+        return 0;
     }
 
-    public E set(int index, E item) {
-        return null;
+    /**
+     * Create a new ImmutableArrayList that added zero or more {@items} starting at {@index}. All original items starting at
+     * {@index} will shift right to make space.
+     *
+     * @param index - index at which the specified element is to be inserted
+     * @param collection - a collection of items to be added at the index
+     *
+     * @return a reference of the new ImmutableArrayList represents the new state after the operation
+     *
+     * @throws IndexOutOfBoundsException if the index is out of range (index < 0 || index > size())
+     */
+    public ImmutableArrayList<E> add(int index, Collection<? extends E> collection) {
+        if (index < 0 || index > size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+
+        Iterator<?> collectionIterator = collection.iterator();
+        Deque<E> shiftItemStack = new LinkedList<E>();
+
+        ImmutableArrayList<E> searchList = new ImmutableArrayList(this, size);
+        Deque<ImmutableArrayList<E>> searchListStack = new LinkedList<ImmutableArrayList<E>>();
+        Deque<Integer> paddingStack = new LinkedList<Integer>();
+        Deque<Integer> sizeIncrementStack = new LinkedList<Integer>();
+        while (collectionIterator.hasNext()) {
+            if(index < searchList.size) {
+                while (index >= searchList.capacity) {
+                    int nextSearchListCapacity = searchList.capacity >> branchFactor;
+                    int nextSearchListIndex = index / nextSearchListCapacity;
+
+                    ImmutableArrayList<E> nextSearchList = (ImmutableArrayList<E>) searchList.list[nextSearchListIndex];
+                    if (nextSearchList == null) {
+                        nextSearchList = new ImmutableArrayList<E>(branchFactor, nextSearchListCapacity, 0);
+                    } else {
+                        nextSearchList = new ImmutableArrayList<E>(nextSearchList, nextSearchList.size);
+                    }
+
+                    int padding = nextSearchListIndex * nextSearchListCapacity;
+                    index -= padding;
+                    paddingStack.push(padding);
+                    searchListStack.push(searchList);
+                    sizeIncrementStack.push(0);
+
+                    searchList = nextSearchList;
+                }
+                while (collectionIterator.hasNext() && index < searchList.size) {
+                    shiftItemStack.addFirst((E) searchList.list[index]);
+                    searchList.list[index] = collectionIterator.next();
+                    index++;
+                }
+                while (collectionIterator.hasNext() && index < searchList.capacity) {
+                    searchList.list[index] = collectionIterator.next();
+                    size++;
+                    sizeIncrementStack.push(sizeIncrementStack.pop() + 1);
+                    index++;
+                }
+            }
+
+            if (!collectionIterator.hasNext()) {
+                if(shiftItemStack.isEmpty()) {
+                    break;
+                }
+                collectionIterator = shiftItemStack.iterator();
+                shiftItemStack.clear();
+            }
+
+            while (!searchListStack.isEmpty() && searchList.size == searchList.capacity) {
+                searchList = searchListStack.pop();
+                index += paddingStack.pop();
+                int sizeIncrement = sizeIncrementStack.pop();
+                sizeIncrementStack.push(sizeIncrementStack.pop() + sizeIncrement);
+                searchList.size += sizeIncrement;
+            }
+
+            if (searchList.size == searchList.capacity) {
+                ImmutableArrayList<E> expandList = new ImmutableArrayList<E>(branchFactor, searchList.capacity << branchFactor, searchList.size);
+                expandList.list[0] = searchList;
+                searchList = expandList;
+            }
+        }
+
+        // TODO: Pop the search stack to update size.
+
+        return searchList;
     }
 
-    public E remove(int index) {
+    private void addAllIterable(Iterator<? extends E> toAddIterable) {
+
+    }
+
+    private void getToSublist(Stack<BacktrackValues<E>> searchStack, ImmutableArrayList<E> searchList) {
+        while(index >= searchList.capacity) {
+            int nextSearchListCapacity = searchList.capacity >> branchFactor;
+            int nextSearchListIndex = index / nextSearchListCapacity;
+            int backtrackPadding = nextSearchListIndex * nextSearchListCapacity;
+            index -= backtrackPadding;
+            searchStack.push(new BacktrackValues<E>(searchList, backtrackPadding));
+
+            ImmutableArrayList<E> nextSearchList = (ImmutableArrayList<E>) searchList.list[nextSearchListIndex];
+            if (nextSearchList == null) {
+                searchList = new ImmutableArrayList<E>(branchFactor, nextSearchListCapacity, Math.min(toAddSize, nextSearchListCapacity));
+            } else {
+                searchList = new ImmutableArrayList<E>(nextSearchList, Math.min(nextSearchList.size + toAddSize, nextSearchList.capacity));
+            }
+        }
+    }
+
+    @Override
+    public Iterator<E> iterator() {
         return null;
     }
-    */
 
 }


### PR DESCRIPTION
Using iterator to add instead of static size, could be helpful for paginated list.
Using single iterator to accomplish the same thing with one while loop instead of 2
Using branchFactor as the bit shift positions instead of base 10 integer multiplier.
Using 3 Deques instead of a wrapper object to utilize naming.
Added size increment stack to better update size of a list that has sublist incremented size.